### PR TITLE
Catools tuples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "python.testing.pytestEnabled": true,
     "python.formatting.provider": "black",
     "python.languageServer": "Microsoft",
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
+    "restructuredtext.confPath": "${workspaceFolder}/docs",
+    "editor.defaultFormatter": null
 }

--- a/aioca/_catools.py
+++ b/aioca/_catools.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Sequence,
     Set,
+    Tuple,
     TypeVar,
     Union,
     overload,
@@ -597,6 +598,18 @@ async def caget(
     ...  # pragma: no cover
 
 
+@overload
+async def caget(
+    pvs: Tuple[str],
+    datatype: Datatype = ...,
+    format: Format = ...,
+    count: Count = ...,
+    timeout: Timeout = ...,
+    throw: bool = ...,
+) -> List[AugmentedValue]:
+    ...  # pragma: no cover
+
+
 @maybe_throw
 async def caget(pv: str, datatype=None, format=dbr.FORMAT_RAW, count=0):
     """Retrieves an `AugmentedValue` from one or more PVs.
@@ -656,6 +669,11 @@ async def caget_array(pvs: List[str], **kwargs):
     return results
 
 
+@caget.register(tuple)  # type: ignore
+async def caget_tuple(pvs: Tuple[str], **kwargs):
+    return await caget_array(list(pvs), **kwargs)
+
+
 # ----------------------------------------------------------------------------
 #   caput
 
@@ -692,6 +710,19 @@ async def caput(
 @overload
 async def caput(
     pvs: List[str],
+    values,
+    repeat_value: bool = ...,
+    datatype: Datatype = ...,
+    wait: bool = ...,
+    timeout: Timeout = ...,
+    throw: bool = ...,
+) -> List[CANothing]:
+    ...  # pragma: no cover
+
+
+@overload
+async def caput(
+    pvs: Tuple[str],
     values,
     repeat_value: bool = ...,
     datatype: Datatype = ...,
@@ -758,8 +789,8 @@ async def caput(pv: str, value, datatype=None, wait=False):
     return CANothing(pv)
 
 
-@caput.register  # type: ignore
-async def caput_array(pvs: list, values, repeat_value=False, **kwargs):
+@caput.register(list)  # type: ignore
+async def caput_array(pvs: List[str], values, repeat_value=False, **kwargs):
     # Bring the arrays of pvs and values into alignment.
     if repeat_value or isinstance(values, str):
         # If repeat_value is requested or the value is a string then we treat
@@ -778,6 +809,11 @@ async def caput_array(pvs: list, values, repeat_value=False, **kwargs):
     ]
     results = await in_parallel(coros, kwargs)
     return results
+
+
+@caput.register(tuple)  # type: ignore
+async def caput_tuple(pvs: Tuple[str], values, repeat_value=False, **kwargs):
+    return await caget(list(pvs), values, repeat_value, **kwargs)
 
 
 # ----------------------------------------------------------------------------
@@ -857,6 +893,13 @@ async def connect(
     ...  # pragma: no cover
 
 
+@overload
+async def connect(
+    pv: Tuple[str], wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
+) -> List[CANothing]:
+    ...  # pragma: no cover
+
+
 @maybe_throw
 async def connect(pv: str, wait=True):
     """Establishes a connection to one or more PVs
@@ -890,6 +933,11 @@ async def connect_array(pvs: List[str], wait=True, **kwargs):
     return results
 
 
+@connect.register(tuple)  # type: ignore
+async def connect_tuple(pvs: Tuple[str], wait=True, **kwargs):
+    return await connect_array(list(pvs), wait, **kwargs)
+
+
 @overload
 async def cainfo(
     pv: str, wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
@@ -900,6 +948,13 @@ async def cainfo(
 @overload
 async def cainfo(
     pv: List[str], wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
+) -> List[CAInfo]:
+    ...  # pragma: no cover
+
+
+@overload
+async def cainfo(
+    pv: Tuple[str], wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
 ) -> List[CAInfo]:
     ...  # pragma: no cover
 
@@ -921,6 +976,11 @@ async def cainfo_array(pvs: List[str], wait=True, **kwargs):
     coros = [cainfo(pv, **parallel_timeout(kwargs)) for pv in pvs]
     results = await in_parallel(coros, kwargs)
     return results
+
+
+@cainfo.register(tuple)  # type: ignore
+async def cainfo_tuple(pvs: Tuple[str], wait=True, **kwargs):
+    return await cainfo_array(list(pvs), wait, **kwargs)
 
 
 # ----------------------------------------------------------------------------

--- a/aioca/_catools.py
+++ b/aioca/_catools.py
@@ -28,7 +28,7 @@ from epicscorelibs.ca import cadef, dbr
 from .types import AugmentedValue, Count, Datatype, Dbe, Format, Timeout
 
 T = TypeVar("T")
-PVS = Union[List[str], Tuple[str]]
+PVS = Union[List[str], Tuple[str, ...]]
 
 DEFAULT_TIMEOUT = 5
 
@@ -488,7 +488,7 @@ def camonitor(
 
 @overload
 def camonitor(
-    pv: List[str],
+    pv: PVS,
     callback: Callable[[Any, int], Union[None, Awaitable]],
     events: Dbe = ...,
     datatype: Datatype = ...,
@@ -763,7 +763,7 @@ async def caput(pv: str, value, datatype=None, wait=False):
 
 @caput.register(list)  # type: ignore
 @caput.register(tuple)  # type: ignore
-async def caput_array(pvs: List[str], values, repeat_value=False, **kwargs):
+async def caput_array(pvs: PVS, values, repeat_value=False, **kwargs):
     # Bring the arrays of pvs and values into alignment.
     if repeat_value or isinstance(values, str):
         # If repeat_value is requested or the value is a string then we treat
@@ -889,7 +889,7 @@ async def connect(pv: str, wait=True):
 
 @connect.register(list)  # type: ignore
 @connect.register(tuple)  # type: ignore
-async def connect_array(pvs: List[str], wait=True, **kwargs):
+async def connect_array(pvs: PVS, wait=True, **kwargs):
     coros = [connect(pv, **parallel_timeout(kwargs)) for pv in pvs]
     results = await in_parallel(coros, kwargs)
     return results

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-epicscorelibs>=7.0.3.99.3.0a1
+epicscorelibs>=7.0.3.99.4.0
 typing_extensions


### PR DESCRIPTION
Make of this what you will.

You cannot `caget(("PV1", "PV2"))` in aioca, but in cothread you can.

We would need a little test refactor for `connect` and `cainfo` as well. 