### PR TITLE
Improve performance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,6 +93,17 @@ each update is called as::
 where index is the position in the original array of pvs of the name
 generating this update.
 
+If an async function as passed as a callback, then it will be awaited and no
+further callbacks will be run for this particular Subscription until this
+completes. This can be useful in conjunction with the default
+``all_updates=False`` for running periodic updating code like::
+
+    async def about_once_a_second(value):
+        do_something_with(value)
+        await asyncio.sleep(1)
+
+    camonitor(pv, callback=about_once_a_second)
+
 Subscriptions will remain active until the :meth:`~Subscription.close()` method
 is called on the returned subscription object:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,12 @@ install_requires =
 
 [options.extras_require]
 # For development tests/docs
-dev = 
+dev =
     black==19.10b0
     # https://github.com/psf/black/issues/2964
     click<8.1.0
     isort>5.0
+    flake8<5
     pytest-asyncio
     pytest-cov
     pytest-mypy
@@ -69,3 +70,4 @@ addopts =
 [coverage:run]
 # This is covered in the versiongit test suite so exclude it here
 omit = */_version_git.py
+data_file = /tmp/aioca.coverage


### PR DESCRIPTION
- Move to a long running task per subscription rather than 1 per update
- Only keep long running task if callback is async
- If callback is sync than execute it in the wakeup function
- Only wakeup asyncio if it isn't already awake

Refs #30 