### PR TITLE
Add ability to coexist with pyepics

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -10,15 +10,20 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9"]
         pipenv: ["skip-lock"]  # --${flag} will be passed to pipenv command
 
         include:
+          # 3.6 only works on ubuntu 20.04
+          - os: "ubuntu-20.04"
+            python: "3.6"
+            pipenv: "skip-lock"
           # Add an extra Python3.7 runner to publish wheels and use the lockfile
           - os: "ubuntu-latest"
             python: "3.7"
             pipenv: "deploy"
             publish: true
+
 
     name: build/${{ matrix.python }}/${{ matrix.os }}/${{ matrix.pipenv }}
     runs-on: ${{ matrix.os }}
@@ -31,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,9 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased_
 -----------
 
-Nothing yet
+Added:
+
+- Support for existing in the same process as pyepics
 
 1.5.1_ - 2022-12-05
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ If running under IPython you can also do awaits from the interactive console::
 How do I pronounce aioca?
 -------------------------
 
-Good question. The closest we have to a canonical pronounciation is eye-oak-ah,
+Good question. The closest we have to a canonical pronounciation is a-o-ka,
 as the alternatives are a bit of a mouthful...
 
 
@@ -102,3 +102,15 @@ The `API` consists of the three functions `caput`, `caget` and `camonitor`
 together with auxilliary `connect` and `cainfo` functions.  The functions
 `caget` and `camonitor` return or deliver "augmented" values which are
 documented in more detail in the `Values` section.
+
+
+Interactions with other CA libraries
+------------------------------------
+
+To ensure some level of interoperability, aioca will only create (and destroy)
+its own CA context if there is not one set for the asyncio event loop thread.
+This means that it is safe to:
+
+- Use aioca and pyepics in different threads
+- Use aioca and pyepics in the same thread as long as pyepics is imported before
+  aioca is first used


### PR DESCRIPTION
To ensure some level of interoperability, aioca will only create (and destroy) its own CA context if there is not one set for the asyncio event loop thread. This means that it is safe to:

- Use aioca and pyepics in different threads
- Use aioca and pyepics in the same thread as long as pyepics is imported before
  aioca is first used