### PR TITLE
Add methods to allow inspecting Channels

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install pipenv build
+          pip install pipenv==2022.4.8 build
           pipenv install --dev --${{ matrix.pipenv }} --python $(python -c 'import sys; print(sys.executable)') && pipenv graph
 
       - name: Create Sdist and Wheel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,9 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased_
 -----------
 
-Nothing yet
+Added: 
+
+- `Add methods to allow inspecting Channels <../../pull/38>`_
 
 1.6_ - 2023-04-06
 -----------------

--- a/aioca/__init__.py
+++ b/aioca/__init__.py
@@ -24,12 +24,14 @@ from epicscorelibs.ca.dbr import (
 from ._catools import (
     CAInfo,
     CANothing,
+    ChannelInfo,
     Subscription,
     caget,
     cainfo,
     camonitor,
     caput,
     connect,
+    get_channel_infos,
     purge_channel_caches,
     run,
 )
@@ -45,6 +47,8 @@ __all__ = [
     "cainfo",  # Returns ca_info describing PV connection
     "CAInfo",  # Ca info object
     "CANothing",  # No value
+    "ChannelInfo",  # Information about a particular channel
+    "get_channel_infos",  # Return information about all channels
     "purge_channel_caches",  # Get rid of old channels
     "run",  # Run one aioca coroutine and clean up
     # The version of aioca

--- a/aioca/_catools.py
+++ b/aioca/_catools.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import time
 import traceback
-from dataclasses import dataclass
 from typing import (
     Any,
     Awaitable,
@@ -1096,7 +1095,6 @@ def get_channel(pv: str) -> Channel:
     return channel
 
 
-@dataclass
 class ChannelInfo:
     """Information about a particular Channel
 
@@ -1109,20 +1107,18 @@ class ChannelInfo:
     connected: bool
     subscriber_count: int
 
+    def __init__(self, name, connected, subscriber_count):
+        self.name = name
+        self.connected = connected
+        self.subscriber_count = subscriber_count
+
 
 def get_channel_infos() -> List[ChannelInfo]:
     """Return information about all Channels"""
-    infos: List[ChannelInfo] = []
-    channel_cache = _Context.get_channel_cache()
-
-    for channel in channel_cache.get_channels():
-        infos.append(
-            ChannelInfo(
-                channel.name, channel.connected(), channel.count_subscriptions()
-            )
-        )
-
-    return infos
+    return [
+        ChannelInfo(channel.name, channel.connected(), channel.count_subscriptions())
+        for channel in _Context.get_channel_cache().get_channels()
+    ]
 
 
 # Another delicacy arising from relying on asynchronous CA event dispatching is

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,6 +141,11 @@ event loop. A convenience function is provided to do this:
 
 .. autofunction:: run
 
+.. autoclass:: ChannelInfo()
+    :members:
+
+.. autofunction:: get_channel_infos
+
 ..  _Values:
 
 Working with Values

--- a/tests/test_aioca.py
+++ b/tests/test_aioca.py
@@ -24,6 +24,7 @@ from aioca import (
     camonitor,
     caput,
     connect,
+    get_channel_infos,
     purge_channel_caches,
     run,
 )
@@ -610,3 +611,34 @@ def test_import_in_a_different_thread(ioc: subprocess.Popen) -> None:
         ]
     )
     assert output.strip() == b"42"
+
+
+@pytest.mark.asyncio
+async def test_channel_connected(ioc: subprocess.Popen) -> None:
+    values: List[AugmentedValue] = []
+    m = camonitor(LONGOUT, values.append, notify_disconnect=True)
+
+    # Wait for connection
+    await poll_length(values)
+
+    channels = get_channel_infos()
+    assert len(channels) == 1
+
+    channel = channels[0]
+    # Initially the PV is connected and has one monitor
+    assert channel.connected
+    assert channel.subscriber_count == 1
+
+    ioc.communicate("exit")
+    await asyncio.sleep(0.1)
+
+    # After IOC exits the channel is disconnected but still has one monitor
+    channel = get_channel_infos()[0]
+    assert not channel.connected
+    assert channel.subscriber_count == 1
+
+    m.close()
+
+    # Once the monitor is closed the subscription disappears
+    channel = get_channel_infos()[0]
+    assert channel.subscriber_count == 0

--- a/tests/test_aioca.py
+++ b/tests/test_aioca.py
@@ -626,6 +626,7 @@ async def test_channel_connected(ioc: subprocess.Popen) -> None:
 
     channel = channels[0]
     # Initially the PV is connected and has one monitor
+    assert channel.name == LONGOUT
     assert channel.connected
     assert channel.subscriber_count == 1
 


### PR DESCRIPTION
Includes converting some methods into dunder methods, as previously Channels have not been public and so this protection was not required.

Fixes #37 