### PR TITLE
Revert changes that removed Python3.8 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,10 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
 
 jobs:
-
   lint:
     uses: ./.github/workflows/_tox.yml
     with:
@@ -19,7 +18,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"
@@ -38,7 +37,6 @@ jobs:
 
   docs:
     uses: ./.github/workflows/_docs.yml
-
 
   dist:
     uses: ./.github/workflows/_dist.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ name = "aioca"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -19,7 +22,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = [

--- a/src/aioca/types.py
+++ b/src/aioca/types.py
@@ -1,6 +1,5 @@
 from datetime import datetime  # noqa
-from typing import Literal, Protocol
-from collections.abc import Sized
+from typing import List, Literal, Protocol, Sized, Tuple, Type, Union
 
 #: A timeout is represented by one of the following
 #:
@@ -10,7 +9,7 @@ from collections.abc import Sized
 #: float    A relative timeout interval in seconds
 #: (float,) An absolute deadline in seconds past epoch
 #: ======== ============================================================
-Timeout = float | tuple[float] | None
+Timeout = Union[None, Tuple[float], float]
 
 #: A bitwise or of DBE event codes from epicscorelibs.ca.dbr
 #:
@@ -35,7 +34,7 @@ Timeout = float | tuple[float] | None
 #: FORMAT_TIME  DBE_VALUE | DBE_ALARM
 #: FORMAT_CTRL  DBE_VALUE | DBE_ALARM | DBE_PROPERTY
 #: ============ =============================================
-Dbe = int | None
+Dbe = Union[None, int]
 
 #: A DBR request code from epicscorelibs.ca.dbr. One of
 #:
@@ -68,7 +67,7 @@ Dbr = Literal[0, 1, 2, 3, 4, 5, 6, 35, 36, 37, 38, 996, 997, 998, 999]
 #:                      such as int, float or str
 #: A numpy dtype        Compatible with any of the above values
 #: ==================== ================================================
-Datatype = Dbr | type | None
+Datatype = Union[None, Dbr, Type]
 
 #: How much auxilliary information will be returned with the retrieved data.
 #: From epicscorelibs.ca.dbr, one of the following
@@ -89,7 +88,7 @@ Format = Literal[0, 1, 2]
 #: -1       The full data length
 #: +ve int  A maximum of this number of elements
 #: ======== ============================================================
-Count = Literal[0, -1] | int
+Count = Union[Literal[0, -1], int]
 
 
 class AugmentedValue(Protocol, Sized):
@@ -153,7 +152,7 @@ class AugmentedValue(Protocol, Sized):
     #: epoch, not the EPICS epoch).  Is a tuple of the form ``(secs, nsec)`` with
     #: integer seconds and nanosecond values, provided in case full ns timestamp
     #: precision is required.
-    raw_stamp: tuple[int, int]
+    raw_stamp: Tuple[int, int]
     #: Timestamp in seconds in format compatible with ``time.time()`` rounded to
     #: the nearest microsecond: for nanosecond precision use `raw_stamp`
     #: instead.
@@ -171,7 +170,7 @@ class AugmentedValue(Protocol, Sized):
     upper_ctrl_limit: float  #: Upper limit for puts to this value
     lower_ctrl_limit: float  #: Lower limit for puts to this value
     precision: int  #: Display precision for floating point values
-    enums: list[str]  #: Enumeration strings for ENUM type
+    enums: List[str]  #: Enumeration strings for ENUM type
     #: Used for global alarm acknowledgement. Do transient alarms have
     #: to be acknowledged? (0,1) means (no, yes).
     ackt: int

--- a/tests/test_aioca.py
+++ b/tests/test_aioca.py
@@ -8,8 +8,8 @@ import sys
 import threading
 import time
 from asyncio.events import AbstractEventLoop
-from collections.abc import Callable
 from pathlib import Path
+from typing import Callable, List, Tuple, Union
 
 import pytest
 from _pytest.unraisableexception import catch_unraisable_exception
@@ -155,7 +155,7 @@ async def test_get_non_existent_pvs_no_throw(ioc: subprocess.Popen) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pvs", ([LONGOUT, SI], (LONGOUT, SI)))
 async def test_get_two_pvs(
-    ioc: subprocess.Popen, pvs: list[str] | tuple[str]
+    ioc: subprocess.Popen, pvs: Union[List[str], Tuple[str]]
 ) -> None:
     value = await caget(pvs, timeout=TIMEOUT)
     assert [42, "me"] == value
@@ -200,7 +200,7 @@ async def test_caput_on_ro_pv_fails(ioc: subprocess.Popen) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pvs", ([LONGOUT, SI], (LONGOUT, SI)))
 async def test_caput_two_pvs_same_value(
-    ioc: subprocess.Popen, pvs: list[str] | tuple[str]
+    ioc: subprocess.Popen, pvs: Union[List[str], Tuple[str]]
 ) -> None:
     await caput(pvs, 43, timeout=TIMEOUT)
     value = await caget(pvs)
@@ -255,7 +255,7 @@ async def poll_length(array, gt=0, timeout=TIMEOUT):
 
 @pytest.mark.asyncio
 async def test_monitor(ioc: subprocess.Popen) -> None:
-    values: list[AugmentedValue] = []
+    values: List[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -276,7 +276,7 @@ async def test_monitor(ioc: subprocess.Popen) -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_with_failing_dbr(ioc: subprocess.Popen, capsys) -> None:
-    values: list[AugmentedValue] = []
+    values: List[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -310,7 +310,7 @@ async def test_monitor_with_failing_dbr(ioc: subprocess.Popen, capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_two_pvs(ioc: subprocess.Popen) -> None:
-    values: list[tuple[AugmentedValue, int]] = []
+    values: List[Tuple[AugmentedValue, int]] = []
     await caput(WAVEFORM, [1, 2], wait=True, timeout=TIMEOUT)
     ms = camonitor([WAVEFORM, LONGOUT], lambda v, n: values.append((v, n)), count=-1)
 
@@ -428,7 +428,7 @@ async def test_exception_raising_monitor_callback(
     assert "ValueError: list.remove(x): x not in list" in captured.err
 
     # Check no more updates
-    values: list[str] = []
+    values: List[str] = []
     m.callback = values.append
     await caput(LONGOUT, 32)
     assert m.state == m.CLOSED
@@ -462,7 +462,7 @@ async def test_async_exception_raising_monitor_callback(
     assert "ValueError: Boom" in captured.err
 
     # Check no more updates
-    values: list[str] = []
+    values: List[str] = []
     m.callback = values.append
     await caput(LONGOUT, 32)
     assert m.state == m.CLOSED
@@ -474,7 +474,7 @@ async def test_async_exception_raising_monitor_callback(
 
 @pytest.mark.asyncio
 async def test_camonitor_non_existent() -> None:
-    values: list[AugmentedValue] = []
+    values: List[AugmentedValue] = []
     m = camonitor(NE, values.append, connect_timeout=0.2)
     try:
         assert len(values) == 0
@@ -504,7 +504,7 @@ async def test_camonitor_non_existent_async() -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_gc(ioc: subprocess.Popen) -> None:
-    values: list[AugmentedValue] = []
+    values: List[AugmentedValue] = []
     camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -648,7 +648,7 @@ async def test_read_pvs_from_different_threads(ioc: subprocess.Popen) -> None:
 
 @pytest.mark.asyncio
 async def test_channel_connected(ioc: subprocess.Popen) -> None:
-    values: list[AugmentedValue] = []
+    values: List[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection


### PR DESCRIPTION
This reverts commits 2870c6e3c659375f82ffa7a9131ddbdc4af00743 and 367ef36874ab2f6ca9d71381ad05acd7640b68e9

There has been no functional code change, it was caused by Ruff auto-updating the code to use the Python3.10+ Typing semantics.