### PR TITLE
Fix an issue with dropped sync callbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
-    "pytest<8",                  # See issue #62
+    "pytest",
     "pytest-asyncio",
     "pytest-cov",
     "ruff",

--- a/src/aioca/_catools.py
+++ b/src/aioca/_catools.py
@@ -407,9 +407,9 @@ class Subscription:
         self: Subscription = args.usr
 
         try:
-            assert args.status == cadef.ECA_NORMAL, (
-                f"Subscription {self.name} got bad status {args.status}"
-            )
+            assert (
+                args.status == cadef.ECA_NORMAL
+            ), f"Subscription {self.name} got bad status {args.status}"
             # Good data: extract value from the dbr. Note that this can fail
             value = self.dbr_to_value(args.raw_dbr, args.type, args.count)
             self.__queue_value(value)

--- a/tests/soft_records.db
+++ b/tests/soft_records.db
@@ -36,3 +36,27 @@ record(longout, "$(P)bad_egus") {
   field(VAL, "32")
   field(EGU, "�")
 }
+
+record(seq, "$(P)seq") {
+    field(SELM, "All")
+    field(LNK1, "$(P)seqout PP")
+    field(LNK2, "$(P)seqout PP")
+    field(LNK3, "$(P)seqout PP")
+    field(LNK4, "$(P)seqout PP")
+    field(LNK5, "$(P)seqout PP")
+    field(LNK6, "$(P)seqout PP")
+    field(LNK7, "$(P)seqout PP")    
+    field(LNK8, "$(P)seqout PP")        
+    field(DO1, "1")
+    field(DO2, "2")
+    field(DO3, "3")
+    field(DO4, "4")
+    field(DO5, "5")
+    field(DO6, "6")
+    field(DO7, "7")
+    field(DO8, "8")
+}
+
+record(longout, "$(P)seqout") {
+  field(PINI, "YES")
+}


### PR DESCRIPTION
When doing camonitor with a sync callback, if the PV receives 2 or more updates between connect and the first callback firing, then only the first callback will be called. This only happens when all_updates=True because with all_updates=False they will be squashed into a single callback with the latest value.

The issue is that __signal wakes up __create_subscription when there are already multiple pending_values, but __create_subscription handles the first, finds it is sync, then hands back to __signal, which is not called on the remaining values. This fixes it by making __create_subscription handle all the updates it finds on the initial pass

Fixes #68 
Fixes #62